### PR TITLE
Add flag to bypass requirement for restart file

### DIFF
--- a/src/icebergs_framework.F90
+++ b/src/icebergs_framework.F90
@@ -435,6 +435,7 @@ type :: icebergs !; private !Niki: Ask Alistair why this is private. ice_bergs_i
   logical :: hexagonal_icebergs=.False. !< True treats icebergs as rectangles, False as hexagonal elements (for the purpose of mass spreading)
   logical :: allow_bergs_to_roll=.True. !< Allows icebergs to roll over when rolling conditions are met
   logical :: ignore_missing_restart_bergs=.False. !< True Allows the model to ignore icebergs missing in the restart.
+  logical :: require_restart=.false. !< If true, requires a restart file to be present when starting the model.
   logical :: Static_icebergs=.False. !< True= icebergs do no move
   logical :: only_interactive_forces=.False. !< Icebergs only feel interactive forces, and not ocean, wind...
   logical :: halo_debugging=.False. !< Use for debugging halos (remove when its working)
@@ -643,6 +644,7 @@ logical :: set_melt_rates_to_zero=.False. ! Sets all melt rates to zero, for tes
 logical :: allow_bergs_to_roll=.True. ! Allows icebergs to roll over when rolling conditions are met
 logical :: hexagonal_icebergs=.False. ! True treats icebergs as rectangles, False as hexagonal elements (for the purpose of mass spreading)
 logical :: ignore_missing_restart_bergs=.False. ! True Allows the model to ignore icebergs missing in the restart.
+logical :: require_restart=.false. ! If true, requires a restart file to be present when starting the model.
 logical :: Static_icebergs=.False. ! True= icebergs do no move
 logical :: only_interactive_forces=.False. ! Icebergs only feel interactive forces, and not ocean, wind...
 logical :: halo_debugging=.False. ! Use for debugging halos (remove when its working)
@@ -676,7 +678,7 @@ namelist /icebergs_nml/ verbose, budget, halo,  traj_sample_hrs, initial_mass, t
          rho_bergs, LoW_ratio, debug, really_debug, use_operator_splitting, bergy_bit_erosion_fraction, iceberg_bonds_on, manually_initialize_bonds, ignore_missing_restart_bergs, &
          parallel_reprod, use_slow_find, sicn_shift, add_weight_to_ocean, passive_mode, ignore_ij_restart, use_new_predictive_corrective, halo_debugging, hexagonal_icebergs, &
          time_average_weight, generate_test_icebergs, speed_limit, fix_restart_dates, use_roundoff_fix, Runge_not_Verlet, interactive_icebergs_on, scale_damping_by_pmag,&
-         critical_interaction_damping_on, tang_crit_int_damp_on, &
+         critical_interaction_damping_on, tang_crit_int_damp_on, require_restart, &
          old_bug_rotated_weights, make_calving_reproduce,restart_input_dir, orig_read, old_bug_bilin,do_unit_tests,grounding_fraction, input_freq_distribution, force_all_pes_traj, &
          allow_bergs_to_roll,set_melt_rates_to_zero,lat_ref,initial_orientation,rotate_icebergs_for_mass_spreading,grid_is_latlon,Lx,use_f_plane,use_old_spreading, &
          grid_is_regular,override_iceberg_velocities,u_override,v_override,add_iceberg_thickness_to_SSH,Iceberg_melt_without_decay,melt_icebergs_as_ice_shelf, &
@@ -1174,6 +1176,7 @@ endif
   bergs%allow_bergs_to_roll=allow_bergs_to_roll
   bergs%hexagonal_icebergs=hexagonal_icebergs
   bergs%ignore_missing_restart_bergs=ignore_missing_restart_bergs
+  bergs%require_restart=require_restart
   bergs%Static_icebergs=Static_icebergs
   bergs%only_interactive_forces=only_interactive_forces
   bergs%halo_debugging=halo_debugging

--- a/src/icebergs_io.F90
+++ b/src/icebergs_io.F90
@@ -581,7 +581,7 @@ integer, allocatable, dimension(:) :: ine,        &
        call read_int_vector(filename,'id_ij',id_ij,grd%domain)
      endif
      call read_real_vector(filename,'static_berg',static_berg,grd%domain,value_if_not_in_file=0.)
-  else
+  elseif (bergs%require_restart) then
      stop 'read_restart_bergs, RESTART NOT FOUND!'
   endif
 

--- a/tests/2p_collision_test/input.nml
+++ b/tests/2p_collision_test/input.nml
@@ -114,6 +114,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all    
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart 
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.false. ! (F) True= Bonds are initialize manually.
     length_for_manually_initialize_bonds=0.0 !(1e3)Dist b/w bergs to init bonds manually    

--- a/tests/chaotic_test/input.nml
+++ b/tests/chaotic_test/input.nml
@@ -111,6 +111,7 @@
     force_all_pes_traj=.false. !(F) Force all pes write traj files regardless of io_layout
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     manually_initialize_bonds_from_radii=.true.!(F) Init bond b/w bergs if dist<1.25*radius

--- a/tests/collision_test/input.nml
+++ b/tests/collision_test/input.nml
@@ -108,6 +108,7 @@
     ignore_traj=.False. ! (F) If true, then model does not track trajectory data at all    
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart 
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     length_for_manually_initialize_bonds=800.0 !(1e3)Dist b/w bergs to init bonds manually    

--- a/tests/collision_test_mts/input.nml
+++ b/tests/collision_test_mts/input.nml
@@ -113,6 +113,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     length_for_manually_initialize_bonds=800.0 !(1e3)Dist b/w bergs to init bonds manually

--- a/tests/energy_test/input.nml
+++ b/tests/energy_test/input.nml
@@ -125,6 +125,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     manually_initialize_bonds_from_radii=.true.!(F) Init bond b/w bergs if dist<1.25*radius

--- a/tests/energy_test2/input.nml
+++ b/tests/energy_test2/input.nml
@@ -124,6 +124,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     manually_initialize_bonds_from_radii=.true.!(F) Init bond b/w bergs if dist<1.25*radius

--- a/tests/energy_test3/input.nml
+++ b/tests/energy_test3/input.nml
@@ -128,6 +128,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     manually_initialize_bonds_from_radii=.true.!(F) Init bond b/w bergs if dist<1.25*radius

--- a/tests/ground_frac_test/input.nml
+++ b/tests/ground_frac_test/input.nml
@@ -129,6 +129,7 @@
     ignore_traj=.false. ! (F) If true, then model does not track trajectory data at all
 
     ignore_missing_restart_bergs=.False. !(F) 'T'=ignore missing bergs in restart
+    require_restart=.true. !(F) 'T'=fail if the restart file is not present at start
     use_slow_find=.true. !(T) Use slow, but robust, find_cell for reading restarts
     manually_initialize_bonds=.true. ! (F) True= Bonds are initialize manually.
     length_for_manually_initialize_bonds=800.0 !(1e3)Dist b/w bergs to init bonds manually


### PR DESCRIPTION
- The FMS policy is to read a restart file if it is present but otherwise do a cold start. For safety reason a "stop" had been added to make sure the model wasn't running "dry" but this broke compatibility with the climate model.
- I've added the namelist parameter `require_restart` which defaults to false to be compatibility with FMS and added it as true in all the test input.nml files.