### PR TITLE
docs: update CPP ifdef logic to set "file version"

### DIFF
--- a/src/icebergs.F90
+++ b/src/icebergs.F90
@@ -85,11 +85,11 @@ real, parameter :: Cd_wh=0.0012 !< (Horizontal) Drag coefficient between bergs a
 real, parameter :: Cd_iv=0.9 !< (Vertical) Drag coefficient between bergs and sea-ice
 !TOM> no horizontal drag for sea ice! real, parameter :: Cd_ih=0.0012 !< (Horizontal) Drag coefficient between bergs and sea-ice
 
-#ifdef _FILE_VERSION
-character(len=128) :: version = _FILE_VERSION !< Version of file
-#else
-character(len=128) :: version = 'unknown' !< Version of file
+#ifndef _FILE_VERSION
+! Version of file provided can be set to git hash via a CPP macro but if not set we use 'unknown'
+#define _FILE_VERSION 'unknown'
 #endif
+character(len=128) :: version = _FILE_VERSION !< Version of file
 
 contains
 

--- a/src/icebergs_framework.F90
+++ b/src/icebergs_framework.F90
@@ -619,12 +619,11 @@ end type icebergs
 !! \todo Remove when backward compatibility no longer needed
 logical :: orig_read=.false.
 
-!> Version of file provided by CPP macro (usually set to git hash)
-#ifdef _FILE_VERSION
-character(len=128) :: version = _FILE_VERSION !< Version of file
-#else
-character(len=128) :: version = 'unknown' !< Version of file
+#ifndef _FILE_VERSION
+! Version of file provided can be set to git hash via a CPP macro but if not set we use 'unknown'
+#define _FILE_VERSION 'unknown'
 #endif
+character(len=128) :: version = _FILE_VERSION !< Version of file
 
 !> Set a value in the buffer at position (counter,n) after incrementing counter
 interface push_buffer_value

--- a/src/icebergs_io.F90
+++ b/src/icebergs_io.F90
@@ -69,11 +69,11 @@ logical :: is_io_tile_root_pe = .true.
 integer :: clock_trw,clock_trp
 integer :: clock_btrw,clock_btrp !bond trajectories
 
-#ifdef _FILE_VERSION
-  character(len=128) :: version = _FILE_VERSION
-#else
-  character(len=128) :: version = 'unknown'
+#ifndef _FILE_VERSION
+! Version of file provided can be set to git hash via a CPP macro but if not set we use 'unknown'
+#define _FILE_VERSION 'unknown'
 #endif
+character(len=128) :: version = _FILE_VERSION !< Version of file
 
 contains
 


### PR DESCRIPTION
doxygen is mishandling the CPP `#ifdef` logic and mishandling differently on different platforms (possible dependence on the version of /lib/cpp). The form of
```
#ifdef
character version = A !< Doc
 #else
character version = B !< Doc
#endif
```
allowed doxygen to see two declarations of a variable.  Refactoring the logic to
```
#ifndef
#define A=B
#endif
character version = A !< Doc
```
seems to fix the problem.